### PR TITLE
This commit reverts 635ac57

### DIFF
--- a/src/image/rotate_worker.cpp
+++ b/src/image/rotate_worker.cpp
@@ -16,12 +16,11 @@ void RotateWorker::Execute () {
     const float nangle = cimg::mod(_degs, 360.0f);
     if (cimg::mod(nangle, 90.0f) != 0) {
         CImg<unsigned char> * res;
-        int channels = _cimg->spectrum();
         size_t oldwidth = _cimg->width(),
                oldheight = _cimg->height();
         try {
             // 2 pixels wider and taller
-            res = new CImg<unsigned char>(oldwidth + 2, oldheight + 2, 1, channels);
+            res = new CImg<unsigned char>(oldwidth + 2, oldheight + 2, 1, N_CHANNELS);
         } catch (CImgException e) {
             SetErrorMessage("Out of memory");
             return;


### PR DESCRIPTION
To be looked at later.
As per EyalAr:
“I like the code to be consistent, so if we leave it like this, we have
to make similar changes in other places in the code.
I agree that this code gives us more flexibility regarding the number
of channels, but we need to design those changes properly, as they
affect other parts of the library.
Let's revert for now, and later decide how we properly bring this back
across the library.”